### PR TITLE
Add a "apt-get update" to fix new issues with NetCDF installation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,10 @@ jobs:
         with:
           lfs: true
 
+      # Update
+      - name: Update
+        run: sudo apt-get update
+
       # Install NetCDF
       - name: Install NetCDF
         run: sudo apt-get install libnetcdf-dev -y


### PR DESCRIPTION
For some reason, the ubuntu build in the CI started to fail during installation of the NetCDF package.  This adds a `apt-get update` to try to fix that issue.