### PR TITLE
Update README.md

### DIFF
--- a/ref/README.md
+++ b/ref/README.md
@@ -38,10 +38,17 @@ the build step. A simple way to do that is with the `file` command as shown belo
 
 ```
 $ file data/inputs/*
-data/inputs/c_sw_12x24.nc: NetCDF Data Format data
-data/inputs/c_sw_24x24.nc: NetCDF Data Format data
-data/inputs/c_sw_48x24.nc: NetCDF Data Format data
-data/inputs/c_sw_48x48.nc: NetCDF Data Format data
+inputs/yppm_0.0.1.nc:  NetCDF Data Format data
+inputs/yppm_0.0.12.nc: NetCDF Data Format data
+inputs/yppm_0.0.3.nc:  NetCDF Data Format data
+inputs/yppm_0.0.6.nc:  NetCDF Data Format data
+inputs/yppm_0.0.7.nc:  NetCDF Data Format data
+inputs/yppm_0.0.8.nc:  NetCDF Data Format data
+inputs/yppm_0.0.9.nc:  NetCDF Data Format data
+inputs/yppm_0.1.15.nc: NetCDF Data Format data
+inputs/yppm_0.1.3.nc:  NetCDF Data Format data
+inputs/yppm_0.1.6.nc:  NetCDF Data Format data
+inputs/yppm_0.1.7.nc:  NetCDF Data Format data
 ```
 
 **NOTE**: If you cloned the repository with a version of git without git-lfs installed,


### PR DESCRIPTION
Change example of verifying files are in NetCDF Data Format in Prerequisites section to reflect the yppm, not c_sw. These examples/output could change if some of these files are deleted with the outstanding feature/interpolate PR.