### PR TITLE
Deleted the aprupt underflow mode.

### DIFF
--- a/ref/src/yppm_driver.f90
+++ b/ref/src/yppm_driver.f90
@@ -30,8 +30,6 @@ program yppm_driver
   integer   :: narg                                  ! # of command line arguments
   integer*8 :: count_start, count_end, count_rate    ! Timer start/stop
   integer   :: ret                                   ! Return status
-  logical   :: underflow_support, gradual, underflow ! Underflow control vars
-  real      :: fptest                                ! Underflow control var
   integer, external :: print_affinity                ! External subroutine
 
   ! Input configuration variables
@@ -64,24 +62,6 @@ program yppm_driver
 
   ! Get OMP_NUM_THREADS value
   nthreads = omp_get_max_threads()
-
-  ! Force thie program to run in abrupt underflow mode
-  ! Intel's -ftz option flushes denormalized values to zero for non-SSE instructions anyway
-  underflow_support = ieee_support_underflow_control(fptest)
-  if (underflow_support) then
-    write (*, *) "Underflow control supported for the default real kind"
-  else
-    write (*, *) "No underflow control support"
-    stop 1
-  end if
-  call ieee_set_underflow_mode(.false.)
-  call ieee_get_underflow_mode(gradual)
-  if (.not. gradual) then
-    write (*, *) "Able to set abrupt underflow mode"
-  else
-    write (*, *) "Error setting abrupt underflow mode"
-    stop 1
-  end if
 
   ! Print out configuration settings
   write (*, '(A,A)') 'Input file = ', TRIM(input_file)


### PR DESCRIPTION
## Proposed changes

Delete all the abrupt-underflow code.

The ARM supercomputer, stria, at the Sandia National Laboratory does not support the IEEEE
subroutines to set the abrupt-underflow code.  This change allows the SENA-yppm kernel
to run on stria without modifications.  In addition, it helps with porting to other architectures
and languages be reducing functionality conversion.

Closes #2  (ARM GCC No underflow support.)

## Types of changes

What types of changes does your code introduce?
_Put an `x` in all the boxes that apply_

- [x] Bugfix (Change which fixes an issue)
- [ ] New feature (Change which adds functionality)
- [ ] Enhancement to existing functionality (non-breaking change which improves existing code or documentation)
- [ ] Breaking change (fix or feature that changes results and requires updates to test baselines)
- [ ] Documentation Update

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/NOAA-GSL/SENA-yppm/blob/develop/CONTRIBUTING.md) document
- [x] I have ensured all my changes contribute to a common purpose
- [x] I have verified my change does not add debug code
- [x] I have verified my change does not add code that is commented out
- [x] I have verified unit tests pass locally with my changes
- [x] I have verified my changes adhere to style guidelines
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
