### PR TITLE
Bugfix/make install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=debug ..
           make
           ctest
+          make install
           
       # Test release mode 
       - name: Test yppm Release
@@ -66,7 +67,8 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=release ..
           make
           ctest       
-       
+          make install
+
   ubuntu_build:
     name: Ubuntu Build
     # Run on ubuntu-latest
@@ -109,6 +111,8 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=debug ..
           make
           ctest
+          make install
+
       # Test release mode
       - name: Build yppm release
         run: |
@@ -121,3 +125,4 @@ jobs:
           cmake -DCMAKE_BUILD_TYPE=release ..
           make
           ctest
+          make install

--- a/ref/src/CMakeLists.txt
+++ b/ref/src/CMakeLists.txt
@@ -17,3 +17,5 @@ if(OpenMP_FOUND)
     target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_C)
 endif()
 
+install(TARGETS ${PROJECT_NAME}
+        DESTINATION ${PROJECT_SOURCE_DIR}/exe)

--- a/ref/test/CMakeLists.txt
+++ b/ref/test/CMakeLists.txt
@@ -115,3 +115,6 @@ add_test(NAME compare_0.0.12_30
 add_test(NAME InterpolateTest 
          COMMAND bash -c "set -o pipefail; ../test/interpolateTest 2>&1 | tee test_output/interpolateTest.out")
 
+# Test install
+add_test(NAME install
+         COMMAND make install)


### PR DESCRIPTION
## Proposed changes

This change reinstates the install target such that a `make install` after a build will install the yppm executable in `ref/exe`. It also adds a test to ensure `make install` works properly going forward.  Finally, a `make test` was added to the CI as well to further ensure that step works as expected.

Closes #22.

## Types of changes

- [x] Bugfix (Change which fixes an issue)
- [ ] New feature (Change which adds functionality)
- [ ] Enhancement to existing functionality (non-breaking change which improves existing code or documentation)
- [ ] Breaking change (fix or feature that changes results and requires updates to test baselines)
- [ ] Documentation Update

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/NOAA-GSL/SENA-yppm/blob/develop/CONTRIBUTING.md) document
- [x] I have ensured all my changes contribute to a common purpose
- [x] I have verified my change does not add debug code
- [x] I have verified my change does not add code that is commented out
- [x] I have verified unit tests pass locally with my changes
- [x] I have verified my changes adhere to style guidelines
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
