### PR TITLE
Added ulimit -s 5000000 to ./ref/build.sh

### DIFF
--- a/ref/README.md
+++ b/ref/README.md
@@ -214,3 +214,10 @@ $ exe/yppm ../test/test_input/yppm_0.0.1.nl
     ```bash
     $ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/path/to/netcdf-c/lib:/path/to/netcdf-fortran/lib
     ```
+
+6. Executing the kernels, I get "forrtl: severe (174): SIGSEGV, segmentation fault occurred"
+ 
+    This error may be due to too small of a stack size.  Try increasing the stack size with:
+    ```bash
+    $ limit -s 5000000 
+    ```

--- a/ref/build.sh
+++ b/ref/build.sh
@@ -61,5 +61,6 @@ make -j4 VERBOSE=1
 export OMP_NUM_THREADS=1
 export OMP_PLACES=cores
 export OMP_PROC_BIND=close
+ulimit -s 5000000
 
 ctest


### PR DESCRIPTION
## Proposed changes

On Orion, `./build.sh intel release` failed unit tests because the stack size was too low.
Added  `ulimit -s 5000000` to `./ref/build.sh`

Closes #25 

## Types of changes

- [x] Bugfix (Change which fixes an issue)
- [x] Enhancement to existing functionality (non-breaking change which improves existing code or documentation)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/NOAA-GSL/SENA-yppm/blob/develop/CONTRIBUTING.md) document
- [x] I have ensured all my changes contribute to a common purpose
- [x] I have verified my change does not add debug code
- [x] I have verified my change does not add code that is commented out
- [x] I have verified my changes adhere to style guidelines

## Further comments

This does not need a unit test because some tests fail if not present.