### PR TITLE
Fix for issues #28 and #29.

### DIFF
--- a/ref/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/ref/cmake/compiler_flags_GNU_Fortran.cmake
@@ -1,16 +1,16 @@
 ####################################################################
 # COMMON FLAGS
 ####################################################################
-set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fbacktrace -ffloat-store -fcray-pointer -fno-unsafe-math-optimizations -frounding-math -ffp-contract=off")
+set( CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -g -fbacktrace -ffloat-store -fcray-pointer -fno-unsafe-math-optimizations -frounding-math -ffp-contract=off")
 
 ####################################################################
 # RELEASE FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_RELEASE "-O2 -march=native -funroll-all-loops -finline-functions")
+set( CMAKE_Fortran_FLAGS_RELEASE "-O3 -march=native -funroll-all-loops -finline-functions")
 
 ####################################################################
 # DEBUG FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O1 -g -fcheck=bounds -ffpe-trap=invalid,zero,overflow" )
+set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -O0 -fcheck=bounds -ffpe-trap=invalid,zero,overflow" )


### PR DESCRIPTION
## Proposed changes

For issue and bug #28, the GNU and Intel debug compilations are not
apples-to-apples.  The GNU debug compilation is at -O1 and the Intel
debug compilation is at -O0.  The compiler creates code motion at
higher and higher optimization levels.  Code motion means that the
assembly instructions are moved around so the CPU can execute the
instructions faster.  To help debug a program, it is helpful to
group the assembly instructions with their source code lines.  The compiler
does this during compilation at -O0.  Code
motion un-groups the instructions, which makes it harder to debug.
So -O0 is the best optimization for debug.  So we are setting the
GNU debug level to -O0.  This makes it apples-to-apples with the
Intel debug level and helps with debugging.

For issue and bug #29, the GNU optimization is -O2 at the release level.
Unfortunately, the GNU compiler does not vectorize at -O2.  So we
are changing the optimization level to -O3, which turns on
vectorization.  This makes it apples-to-apples with the Intel
release optimization level.

Closes #28
Closes #29. 

## Types of changes

What types of changes does your code introduce?

- [x] Bugfix (Change which fixes an issue)
- [x] Enhancement to existing functionality (non-breaking change which improves existing code or documentation)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/NOAA-GSL/SENA-yppm/blob/develop/CONTRIBUTING.md) document
- [x] I have ensured all my changes contribute to a common purpose
- [x] I have verified my change does not add debug code
- [x] I have verified my change does not add code that is commented out
- [x] I have verified unit tests pass locally with my changes
- [x] I have verified my changes adhere to style guidelines

## Further comments

Probably someone is going to comment that fixing two bugs with one pull request is 
not correct GitHub etiquette.  But the changes are small and in one file and it is more
work to do two pull requests than one pull request.  